### PR TITLE
build: treat warnings as errors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "check-success=success"
       - "base=main"
-      - "label=!squash"
+      - "label=rebase"
       - -draft
       - -conflict
     actions:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Template for Kotlin jvm projects
+
+This template is a starting point for a Kotlin JVM project for Postion Pal organition.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.qa)
-    alias(libs.plugins.kotlin.sv)
     alias(libs.plugins.kotlin.dokka)
+    alias(libs.plugins.git.semantic.versioning)
 }
 
 allprojects {
@@ -29,6 +29,12 @@ subprojects {
             implementation(kotlin.stdlib)
             implementation(kotlin.stdlib.jdk8)
             testImplementation(bundles.kotlin.testing)
+        }
+    }
+
+    kotlin {
+        compilerOptions {
+            allWarningsAsErrors = true
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,5 +16,5 @@ kotlin-testing = [ "kotest-junit5-jvm", "kotest-assertions-core-jvm", "mockito-c
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-qa = "org.danilopianini.gradle-kotlin-qa:0.62.3"
-kotlin-sv = "org.danilopianini.git-sensitive-semantic-versioning:3.1.7"
 kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
+git-semantic-versioning = "org.danilopianini.git-sensitive-semantic-versioning:3.1.7"


### PR DESCRIPTION
- Add a simple README
- consider warning as errors
- rename plugin with wrong name