### PR TITLE
Refactoring of CI scripts and fix success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: Build, Test and Check
 
 on:
   push:
@@ -24,40 +24,45 @@ jobs:
         os: [windows, macos, ubuntu]
         jvm-version: [ 11, 17, 21 ]
     runs-on: ${{ matrix.os }}-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
       - name: Set up JDK ${{ matrix.jvm-version }}
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.jvm-version }}
-
-      - name: Assemble
-        run: ./gradlew assemble
-
-      - name: Build
-        run: ./gradlew build
-
+      - name: Assemble main and test classes
+        run: ./gradlew classes testClasses
       - name: Test
         run: ./gradlew test
-
       - name: Check
         run: ./gradlew check
 
   success:
-    needs: build
-    if: always()
+    needs:
+      - build
+    if: >- # run if any needed job failed or if no needed job was cancelled
+      always() && (
+        contains(join(needs.*.result, ','), 'failure')
+        || !contains(join(needs.*.result, ','), 'cancelled')
+      )
     runs-on: ubuntu-latest
     steps:
-      - name: Final Check
-        run: echo "All builds passed successfully!"
+      - name: Verify no failures occurred in needed jobs
+        # if there are failures, false is executed and the job fails.
+        run: ${{ !contains(join(needs.*.result, ','), 'failure') }}
 
   deploy:
     needs:
       - success
     uses: ./.github/workflows/publish.yml
+    if: github.ref_name == 'master' || github.ref_name == 'main'
+    secrets: inherit
+
+  publish-api-doc:
+    needs:
+      - success
+    uses: ./.github/workflows/dokka-gh-pages.yml
     if: github.ref_name == 'master' || github.ref_name == 'main'
     secrets: inherit

--- a/.github/workflows/dokka-gh-pages.yml
+++ b/.github/workflows/dokka-gh-pages.yml
@@ -1,27 +1,22 @@
 name: Generate and Deploy Dokka Documentation
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:
           distribution: 'temurin'
-          java-version: '11'
-
+          java-version: '21'
       - name: Build documentation
         run: ./gradlew dokkaHtmlMultiModule
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,41 +1,36 @@
-name: release-version
+name: Release version
+
 on:
   workflow_call:
   workflow_dispatch:
 
 jobs:
   release-and-delivery:
-    permissions:
+    permissions: # Not specified scopes are set to `none`!
       packages: write
+      contents: write
     concurrency:
       group: release-and-delivery-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     outputs:
       release-status: ${{ env.release_status }}
-
     steps:
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           submodules: recursive
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
-
-      - name: Get All Tags
-        run: git fetch --tags -f
-
+          fetch-tags: true
       - name: Find the version of Node from package.json
         id: node-version
         run: echo "version=$(jq -r .engines.node package.json)" >> $GITHUB_OUTPUT
-
       - name: Install Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
           node-version: ${{ steps.node-version.outputs.version }}
-
       - name: Release
         run: |
           npm install
           npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
While reviewing CI scripts to include them in the Scala template I spotted a few improvements:

- `ci.yml`
  - `./gradlew assemble` does not assemble test classes -> replaced with `./gradlew classes testClasses` which does;
  - `./gradlew build` is not needed since it assemble + test + check 
  - the if condition of `success` job has been fixed. With only the `always()` condition, this job would always succeed even when the build fails, which I think was not intended (otherwise Mergify could merge broken stuff). With the updated condition, this job is run when one of the needed jobs fails or none is canceled and it terminates by failing if a needed job fails;

- `dokka-gh-pages`
  - use newer LTS java;
  - since I removed the branch protection rule "require status checks to pass", the Dokka documentation generation is triggered only upon the success of the `success` job.

- `publish.yml`
  - the `git fetch --tags` step is replaced by the option `fetch-tags` of the `checkout` action;
  - no need for a custom `secrets.RELEASE_TOKEN`, the automatic `{{ github.token }}` is fine
    - the `permissions` entry applies to the `{{ github.token }}`

Any suggestions for improvements, errors, or anything you don't like are welcome 😄